### PR TITLE
Add nix-darwin + home-manager configuration for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # Work
 plugins/ashby.zsh
+
+# Nix
+result

--- a/NIX.md
+++ b/NIX.md
@@ -1,0 +1,227 @@
+# Nix Configuration
+
+This repo uses [nix-darwin](https://github.com/LnL7/nix-darwin) and [home-manager](https://github.com/nix-community/home-manager) to declaratively manage macOS environments. It replaces `install.sh` (package installation) and `symlink.sh` (dotfile linking) with a single reproducible configuration.
+
+## Prerequisites
+
+1. **Homebrew** — must be installed first (nix-darwin manages casks through it, but does not install Homebrew itself):
+
+   ```sh
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+2. **Nix** — install via the [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer) (recommended over the official installer):
+
+   ```sh
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh
+   ```
+
+3. **Clone this repo** to `~/.dotfiles` (the zshrc and nix config both expect this path):
+
+   ```sh
+   git clone https://github.com/geekjuice/dotfiles.git ~/.dotfiles
+   ```
+
+## Quick Start
+
+```sh
+cd ~/.dotfiles
+darwin-rebuild switch --flake .#nick
+```
+
+That's it. This single command will:
+
+- Install all CLI tools via nix
+- Install all GUI apps via Homebrew casks
+- Symlink all dotfiles to their expected locations
+- Bootstrap TPM (tmux plugin manager) and install tmux plugins
+- Generate local SSL certificates via mkcert (if not already present)
+
+Open a new terminal session afterward for all shell changes to take effect.
+
+Neovim plugins are managed by lazy.nvim and self-bootstrap on first launch. Zim (zsh framework) also self-installs on first shell session.
+
+## What Gets Installed
+
+### CLI Packages (via nix)
+
+Managed in `nix/home.nix`. Installed into the nix profile — no Homebrew needed for these.
+
+| Category | Packages |
+|----------|----------|
+| Shells | zsh, bash |
+| Version management | mise |
+| File & directory | eza, fd, yazi, zoxide |
+| Editors | vim, neovim |
+| Git | git, gh, git-delta, lazygit |
+| Terminal multiplexer | tmux, tmuxp |
+| Search | ripgrep, fzf |
+| Data & JSON | bat, jq, jnv, fx |
+| System & utilities | htop, watch, viddy, rsync, coreutils, gnused, dust, icloudpd |
+| Diff & color | difftastic, pastel |
+| Security | mkcert |
+| Dev tools | direnv, worktrunk, stylua |
+
+### GUI Apps (via Homebrew casks)
+
+Managed in `nix/darwin.nix`. nix-darwin runs `brew bundle` under the hood.
+
+arc, bitwarden, claude-code, cleanshot, clop, conductor, discord, docker-desktop, figma, font-hack-nerd-font, ghostty, google-chrome, hammerspoon, httpie-desktop, iterm2, jordanbaird-ice, meetingbar, proxyman, raycast, slack, spotify, syncthing-app, tailscale-app, temurin, visual-studio-code
+
+### Homebrew Formulae
+
+Only packages that require Homebrew-specific paths stay as brews:
+
+- `pam-reattach` — needs `/opt/homebrew/lib/pam/` for sudo Touch ID support
+
+## What Gets Symlinked
+
+Managed in `nix/home.nix` via `home.file`. All symlinks point directly at repo files, so edits are live without rebuilding.
+
+| Category | Targets |
+|----------|---------|
+| Home dotfiles | `.zshrc`, `.zimrc`, `.editorconfig`, `.gitconfig`, `.gitignore`, `.tmux.conf`, `.tmuxline.conf`, `.inputrc`, `.npmrc`, `.psqlrc`, `.ripgreprc`, `.tool-versions`, `.hushlogin`, `.default-npm-packages` |
+| Directories | `.localssl/`, `.hammerspoon/`, `.githooks/`, `.agents/`, `.tmuxp/` |
+| XDG config | `nvim/`, `yazi/`, `direnv/direnv.toml`, `worktrunk/config.toml`, `dex/dex.toml` |
+| macOS App Support | `lazygit/config.yml`, `com.mitchellh.ghostty/config` |
+| Claude | `CLAUDE.md`, `keybindings.json`, `settings.json`, `skills/pr` |
+
+## Automatic Setup
+
+The following are handled by `home.activation` scripts in `nix/home.nix`. They run during every `darwin-rebuild switch` and are idempotent (skip if already done).
+
+- **TPM** — clones tmux plugin manager to `~/.tmux/plugins/tpm` if missing, then installs plugins
+- **mkcert** — runs `mkcert -install` and generates `localhost.pem`/`localhost.key` if the cert files don't exist
+
+### Self-Bootstrapping Tools
+
+These tools manage their own setup automatically — no activation scripts needed:
+
+- **lazy.nvim** — neovim plugin manager, bootstraps from `nvim/init.lua` on first launch
+- **zim** — zsh framework, bootstraps from `zshrc` on first shell session
+
+## Day-to-Day Usage
+
+### Rebuild after config changes
+
+```sh
+darwin-rebuild switch --flake ~/.dotfiles#nick
+```
+
+Run this after editing any file in `nix/`. Dotfile content changes (e.g., editing `zshrc`, `nvim/`) do **not** require a rebuild since they're symlinked directly.
+
+### Add a new CLI package
+
+Edit `nix/home.nix` and add to `home.packages`:
+
+```nix
+home.packages = with pkgs; [
+  # ...existing packages...
+  newpackage
+];
+```
+
+Then rebuild.
+
+### Add a new GUI app (cask)
+
+Edit `nix/darwin.nix` and add to `homebrew.casks`:
+
+```nix
+casks = [
+  # ...existing casks...
+  "new-cask"
+];
+```
+
+Then rebuild. Note: `cleanup = "zap"` means any cask installed via Homebrew but **not** listed here will be removed on rebuild.
+
+### Update all nix inputs
+
+```sh
+cd ~/.dotfiles
+nix flake update
+darwin-rebuild switch --flake .#nick
+```
+
+This pulls the latest nixpkgs, nix-darwin, and home-manager.
+
+### Garbage collection
+
+```sh
+# Remove old generations and unreferenced store paths
+nix-collect-garbage -d
+```
+
+## File Structure
+
+```
+dotfiles/
+  flake.nix          # Flake entry point — inputs (nixpkgs, nix-darwin, home-manager)
+                     # and the darwinConfigurations."nick" definition
+  nix/
+    darwin.nix       # System-level: Homebrew casks/brews, nix settings, shell, user
+    home.nix         # User-level: CLI packages, dotfile symlinks, activation scripts
+```
+
+## Post-Install (Manual)
+
+These steps can't be automated via nix:
+
+### Touch ID for sudo
+
+```sh
+sudo vim /etc/pam.d/sudo_local
+```
+
+Add these lines at the top:
+
+```
+auth optional /opt/homebrew/lib/pam/pam_reattach.so
+auth sufficient pam_tid.so
+```
+
+### iTerm2 session persistence
+
+Set `Prefs > Advanced > Allow sessions to survive logging out and back in` to **No**.
+
+### Nord iTerm2 theme
+
+One-time import:
+
+```sh
+curl -OL https://raw.githubusercontent.com/arcticicestudio/nord-iterm2/master/src/xml/Nord.itermcolors
+open Nord.itermcolors
+rm Nord.itermcolors
+```
+
+## Troubleshooting
+
+### `darwin-rebuild: command not found`
+
+After installing nix, open a new terminal or run:
+
+```sh
+source /etc/zshrc
+```
+
+### Homebrew not found during rebuild
+
+nix-darwin expects Homebrew at `/opt/homebrew/bin/brew` (Apple Silicon) or `/usr/local/bin/brew` (Intel). Ensure Homebrew is installed before running `darwin-rebuild switch`.
+
+### PATH conflicts between nix and Homebrew
+
+Nix packages take precedence when nix paths appear earlier in `$PATH`. If you need the Homebrew version of a tool, either remove it from `home.packages` or adjust PATH ordering in `zshrc`.
+
+### Homebrew cask removed unexpectedly
+
+The `cleanup = "zap"` setting removes any Homebrew-managed formula or cask not declared in `darwin.nix`. To keep manually-installed casks alongside the nix config, change to `cleanup = "none"` in `nix/darwin.nix`.
+
+### Symlink conflicts
+
+If `darwin-rebuild switch` fails with "existing file" errors, the target file already exists and isn't a symlink. Back it up and remove it:
+
+```sh
+mv ~/.zshrc ~/.zshrc.bak
+darwin-rebuild switch --flake ~/.dotfiles#nick
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "macOS dotfiles";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, nix-darwin, home-manager, ... }: {
+    darwinConfigurations."nick" = nix-darwin.lib.darwinSystem {
+      system = "aarch64-darwin";
+      modules = [
+        ./nix/darwin.nix
+        home-manager.darwinModules.home-manager
+        {
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.users.nick = import ./nix/home.nix;
+        }
+      ];
+    };
+  };
+}

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,0 +1,62 @@
+{ pkgs, ... }:
+
+{
+  # ──────────────────────────────────────────────
+  # Homebrew (nix-darwin manages the bundle declaratively)
+  # NOTE: Homebrew itself must be pre-installed
+  # ──────────────────────────────────────────────
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = true;
+      cleanup = "zap"; # remove formulae/casks not declared here
+    };
+    casks = [
+      "arc"
+      "bitwarden"
+      "claude-code"
+      "cleanshot"
+      "clop"
+      "conductor"
+      "discord"
+      "docker-desktop"
+      "figma"
+      "font-hack-nerd-font"
+      "ghostty"
+      "google-chrome"
+      "hammerspoon"
+      "httpie-desktop"
+      "iterm2"
+      "jordanbaird-ice"
+      "meetingbar"
+      "proxyman"
+      "raycast"
+      "slack"
+      "spotify"
+      "syncthing-app"
+      "tailscale-app"
+      "temurin"
+      "visual-studio-code"
+    ];
+    # Packages that must come from Homebrew (no nix equivalent or path-dependent)
+    brews = [
+      "pam-reattach" # needs /opt/homebrew/lib/pam/ path for sudo Touch ID
+    ];
+  };
+
+  # ──────────────────────────────────────────────
+  # Nix
+  # ──────────────────────────────────────────────
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  # ──────────────────────────────────────────────
+  # System
+  # ──────────────────────────────────────────────
+  programs.zsh.enable = true;
+  system.stateVersion = 5;
+
+  users.users.nick = {
+    name = "nick";
+    home = "/Users/nick";
+  };
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,0 +1,158 @@
+{ pkgs, ... }:
+
+let
+  dotfilesDir = "/Users/nick/.dotfiles";
+in
+{
+  home.stateVersion = "24.05";
+
+  # ──────────────────────────────────────────────
+  # CLI Packages (replaces `brew install` from Brewfile)
+  # ──────────────────────────────────────────────
+  home.packages = with pkgs; [
+    # shells
+    zsh
+    bash
+
+    # version management
+    mise
+
+    # file & directory
+    eza
+    fd
+    yazi
+    zoxide
+
+    # editors
+    vim
+    neovim
+
+    # git
+    git
+    gh
+    git-delta
+    lazygit
+
+    # terminal multiplexer
+    tmux
+    tmuxp
+
+    # search
+    ripgrep
+    fzf
+
+    # data & json
+    bat
+    jq
+    jnv
+    fx
+
+    # system & utilities
+    htop
+    watch
+    viddy
+    rsync
+    coreutils
+    gnused
+    dust
+    icloudpd
+
+    # diff & color
+    difftastic
+    pastel
+
+    # security
+    mkcert
+
+    # dev tools
+    direnv
+    worktrunk
+    stylua
+  ];
+
+  # ──────────────────────────────────────────────
+  # Dotfile symlinks (replaces symlink.sh)
+  #
+  # Using absolute paths so nix creates symlinks pointing directly
+  # at the repo files — edits are live without rebuilding.
+  # ──────────────────────────────────────────────
+  home.file = {
+    # ── Home dotfiles ──
+    ".editorconfig".source        = "${dotfilesDir}/editorconfig";
+    ".gitconfig".source           = "${dotfilesDir}/gitconfig";
+    ".gitignore".source           = "${dotfilesDir}/gitignore";
+    ".githooks".source            = "${dotfilesDir}/githooks";
+    ".hammerspoon".source         = "${dotfilesDir}/hammerspoon";
+    ".hushlogin".source           = "${dotfilesDir}/hushlogin";
+    ".inputrc".source             = "${dotfilesDir}/inputrc";
+    ".npmrc".source               = "${dotfilesDir}/npmrc";
+    ".psqlrc".source              = "${dotfilesDir}/psqlrc";
+    ".ripgreprc".source           = "${dotfilesDir}/ripgreprc";
+    ".tmux.conf".source           = "${dotfilesDir}/tmux.conf";
+    ".tmuxline.conf".source       = "${dotfilesDir}/tmuxline.conf";
+    ".tool-versions".source       = "${dotfilesDir}/tool-versions";
+    ".zshrc".source               = "${dotfilesDir}/zshrc";
+    ".zimrc".source               = "${dotfilesDir}/zimrc";
+
+    # ── Directories ──
+    ".localssl".source            = "${dotfilesDir}/localssl";
+    ".agents".source              = "${dotfilesDir}/agents";
+    ".tmuxp".source               = "${dotfilesDir}/tmuxp";
+
+    # ── npm ──
+    ".default-npm-packages".source = "${dotfilesDir}/default-npm-packages";
+
+    # ── XDG config ──
+    ".config/direnv/direnv.toml".source    = "${dotfilesDir}/direnv.toml";
+    ".config/yazi".source                  = "${dotfilesDir}/yazi";
+    ".config/nvim".source                  = "${dotfilesDir}/nvim";
+    ".config/worktrunk/config.toml".source = "${dotfilesDir}/worktrunk.toml";
+    ".config/dex/dex.toml".source          = "${dotfilesDir}/dex.toml";
+
+    # ── macOS Application Support ──
+    "Library/Application Support/lazygit/config.yml".source        = "${dotfilesDir}/lazygit.yml";
+    "Library/Application Support/com.mitchellh.ghostty/config".source = "${dotfilesDir}/ghostty";
+
+    # ── Claude ──
+    ".claude/CLAUDE.md".source         = "${dotfilesDir}/claude/CLAUDE.md";
+    ".claude/keybindings.json".source  = "${dotfilesDir}/claude/keybindings.json";
+    ".claude/settings.json".source     = "${dotfilesDir}/claude/settings.json";
+    ".claude/skills/pr".source         = "${dotfilesDir}/claude/skills/pr";
+  };
+
+  # ──────────────────────────────────────────────
+  # Activation scripts (replaces one-time install steps)
+  #
+  # These are idempotent — safe to re-run on every switch.
+  # ──────────────────────────────────────────────
+  home.activation = {
+    # TPM + tmux plugins
+    installTpm = ''
+      TPM_DIR="$HOME/.tmux/plugins/tpm"
+      if [ ! -d "$TPM_DIR" ]; then
+        ${pkgs.git}/bin/git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+      fi
+      if [ -x "$TPM_DIR/bin/install_plugins" ]; then
+        "$TPM_DIR/bin/install_plugins" || true
+      fi
+    '';
+
+    # mkcert local SSL certificates
+    installLocalSsl = ''
+      CERT_FILE="${dotfilesDir}/localssl/localhost.pem"
+      KEY_FILE="${dotfilesDir}/localssl/localhost.key"
+      if [ ! -f "$CERT_FILE" ] || [ ! -f "$KEY_FILE" ]; then
+        ${pkgs.mkcert}/bin/mkcert -install 2>/dev/null || true
+        ${pkgs.mkcert}/bin/mkcert \
+          -cert-file "$CERT_FILE" \
+          -key-file "$KEY_FILE" \
+          localhost
+      fi
+    '';
+  };
+
+  # ──────────────────────────────────────────────
+  # Let home-manager manage itself
+  # ──────────────────────────────────────────────
+  programs.home-manager.enable = true;
+}


### PR DESCRIPTION
Introduces a nix flake that replaces install.sh and symlink.sh with
declarative config: nix-darwin for Homebrew cask management, home-manager
for CLI packages and dotfile symlinks.

Usage: darwin-rebuild switch --flake ~/.dotfiles#nick

https://claude.ai/code/session_01JyqKSkqERTmHJw2HDwbp5o