### PR TITLE
:doughnut: add donut — lightweight Slack pairing bot

### DIFF
--- a/donut/.env.example
+++ b/donut/.env.example
@@ -1,0 +1,13 @@
+# Slack App Credentials (from api.slack.com/apps)
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+SLACK_CLIENT_ID=your-client-id
+SLACK_CLIENT_SECRET=your-client-secret
+SLACK_STATE_SECRET=a-random-string-for-oauth-state
+
+# Server
+PORT=3000
+HOST=0.0.0.0
+
+# Database
+DATABASE_URL=./donut.db

--- a/donut/.gitignore
+++ b/donut/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+.env
+.DS_Store
+bun.lockb

--- a/donut/bun.lock
+++ b/donut/bun.lock
@@ -1,0 +1,453 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "donut",
+      "dependencies": {
+        "@slack/bolt": "^4",
+        "croner": "^9",
+        "drizzle-orm": "^0.44",
+        "hono": "^4",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "drizzle-kit": "^0.31",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@slack/bolt": ["@slack/bolt@4.7.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/oauth": "^3.0.5", "@slack/socket-mode": "^2.0.6", "@slack/types": "^2.20.1", "@slack/web-api": "^7.15.0", "axios": "^1.12.0", "express": "^5.0.0", "path-to-regexp": "^8.1.0", "raw-body": "^3", "tsscmp": "^1.0.6" }, "peerDependencies": { "@types/express": "^5.0.0" } }, "sha512-Xpf+gKegNvkHpft1z4YiuqZdciJ3tUp1bIRQxylW30Ovf+hzjb0M1zTHVtJsRw9jsjPxHTPoyanEXVvG6qVE1g=="],
+
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/oauth": ["@slack/oauth@3.0.5", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/jsonwebtoken": "^9", "@types/node": ">=18", "jsonwebtoken": "^9" } }, "sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A=="],
+
+    "@slack/socket-mode": ["@slack/socket-mode@2.0.6", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ=="],
+
+    "@slack/types": ["@slack/types@2.20.1", "", {}, "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A=="],
+
+    "@slack/web-api": ["@slack/web-api@7.15.1", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.20.1", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.15.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "croner": ["croner@9.1.0", "", {}, "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.44.7", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tsscmp": ["tsscmp@1.0.6", "", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+  }
+}

--- a/donut/drizzle.config.ts
+++ b/donut/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/db/schema.ts",
+  out: "./drizzle/migrations",
+  dbCredentials: {
+    url: process.env.DATABASE_URL ?? "./donut.db",
+  },
+});

--- a/donut/drizzle/migrations/0000_crazy_hemingway.sql
+++ b/donut/drizzle/migrations/0000_crazy_hemingway.sql
@@ -1,0 +1,59 @@
+CREATE TABLE `channels` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`workspace_id` text NOT NULL,
+	`channel_id` text NOT NULL,
+	`channel_name` text NOT NULL,
+	`group_size` integer DEFAULT 3 NOT NULL,
+	`frequency` text DEFAULT '0 10 * * 1' NOT NULL,
+	`timezone` text DEFAULT 'America/New_York' NOT NULL,
+	`cooldown_rounds` integer DEFAULT 3 NOT NULL,
+	`timezone_mode` integer DEFAULT false NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `channels_workspace_channel_idx` ON `channels` (`workspace_id`,`channel_id`);--> statement-breakpoint
+CREATE TABLE `members` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`channel_config_id` integer NOT NULL,
+	`user_id` text NOT NULL,
+	`display_name` text NOT NULL,
+	`timezone` text DEFAULT 'UTC',
+	`is_active` integer DEFAULT true NOT NULL,
+	`is_paused` integer DEFAULT false NOT NULL,
+	`joined_at` integer NOT NULL,
+	FOREIGN KEY (`channel_config_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `members_channel_user_idx` ON `members` (`channel_config_id`,`user_id`);--> statement-breakpoint
+CREATE TABLE `pairing_members` (
+	`pairing_id` integer NOT NULL,
+	`user_id` text NOT NULL,
+	PRIMARY KEY(`pairing_id`, `user_id`),
+	FOREIGN KEY (`pairing_id`) REFERENCES `pairings`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `pairings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`round_id` integer NOT NULL,
+	`group_index` integer NOT NULL,
+	FOREIGN KEY (`round_id`) REFERENCES `rounds`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `rounds` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`channel_config_id` integer NOT NULL,
+	`executed_at` integer NOT NULL,
+	`group_count` integer NOT NULL,
+	FOREIGN KEY (`channel_config_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `workspaces` (
+	`id` text PRIMARY KEY NOT NULL,
+	`team_name` text NOT NULL,
+	`bot_token` text NOT NULL,
+	`installed_at` integer NOT NULL,
+	`installed_by` text NOT NULL
+);

--- a/donut/drizzle/migrations/meta/0000_snapshot.json
+++ b/donut/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,421 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e9d7d4f6-2950-4ab3-9ee8-58c211a3e9d4",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_size": {
+          "name": "group_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0 10 * * 1'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/New_York'"
+        },
+        "cooldown_rounds": {
+          "name": "cooldown_rounds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "timezone_mode": {
+          "name": "timezone_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channels_workspace_channel_idx": {
+          "name": "channels_workspace_channel_idx",
+          "columns": [
+            "workspace_id",
+            "channel_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channels_workspace_id_workspaces_id_fk": {
+          "name": "channels_workspace_id_workspaces_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "members": {
+      "name": "members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_config_id": {
+          "name": "channel_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_paused": {
+          "name": "is_paused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "members_channel_user_idx": {
+          "name": "members_channel_user_idx",
+          "columns": [
+            "channel_config_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "members_channel_config_id_channels_id_fk": {
+          "name": "members_channel_config_id_channels_id_fk",
+          "tableFrom": "members",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pairing_members": {
+      "name": "pairing_members",
+      "columns": {
+        "pairing_id": {
+          "name": "pairing_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_members_pairing_id_pairings_id_fk": {
+          "name": "pairing_members_pairing_id_pairings_id_fk",
+          "tableFrom": "pairing_members",
+          "tableTo": "pairings",
+          "columnsFrom": [
+            "pairing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pairing_members_pairing_id_user_id_pk": {
+          "columns": [
+            "pairing_id",
+            "user_id"
+          ],
+          "name": "pairing_members_pairing_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pairings": {
+      "name": "pairings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_index": {
+          "name": "group_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairings_round_id_rounds_id_fk": {
+          "name": "pairings_round_id_rounds_id_fk",
+          "tableFrom": "pairings",
+          "tableTo": "rounds",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rounds": {
+      "name": "rounds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_config_id": {
+          "name": "channel_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_count": {
+          "name": "group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rounds_channel_config_id_channels_id_fk": {
+          "name": "rounds_channel_config_id_channels_id_fk",
+          "tableFrom": "rounds",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed_by": {
+          "name": "installed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/donut/drizzle/migrations/meta/_journal.json
+++ b/donut/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1776355325393,
+      "tag": "0000_crazy_hemingway",
+      "breakpoints": true
+    }
+  ]
+}

--- a/donut/package.json
+++ b/donut/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "donut",
+  "version": "0.0.1",
+  "description": "Lightweight Slack team pairing bot — a self-hosted Donut alternative",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "start": "bun run src/index.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@slack/bolt": "^4",
+    "croner": "^9",
+    "drizzle-orm": "^0.44",
+    "hono": "^4"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "drizzle-kit": "^0.31",
+    "typescript": "^5"
+  }
+}

--- a/donut/src/db/client.ts
+++ b/donut/src/db/client.ts
@@ -1,0 +1,11 @@
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "./schema";
+import { env } from "../env";
+
+const sqlite = new Database(env.databaseUrl);
+sqlite.run("PRAGMA journal_mode = WAL");
+sqlite.run("PRAGMA foreign_keys = ON");
+
+export const db = drizzle(sqlite, { schema });
+export type Db = typeof db;

--- a/donut/src/db/schema.ts
+++ b/donut/src/db/schema.ts
@@ -1,0 +1,81 @@
+import { sqliteTable, text, integer, primaryKey, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+// --- Workspaces ---
+
+export const workspaces = sqliteTable("workspaces", {
+  id: text("id").primaryKey(), // Slack team_id
+  teamName: text("team_name").notNull(),
+  botToken: text("bot_token").notNull(),
+  installedAt: integer("installed_at", { mode: "timestamp_ms" }).notNull(),
+  installedBy: text("installed_by").notNull(),
+});
+
+// --- Channel Configs ---
+
+export const channels = sqliteTable("channels", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  workspaceId: text("workspace_id")
+    .notNull()
+    .references(() => workspaces.id, { onDelete: "cascade" }),
+  channelId: text("channel_id").notNull(),
+  channelName: text("channel_name").notNull(),
+  groupSize: integer("group_size").notNull().default(3),
+  frequency: text("frequency").notNull().default("0 10 * * 1"), // Mon 10am
+  timezone: text("timezone").notNull().default("America/New_York"),
+  cooldownRounds: integer("cooldown_rounds").notNull().default(3),
+  timezoneMode: integer("timezone_mode", { mode: "boolean" }).notNull().default(false),
+  isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+}, (table) => [
+  uniqueIndex("channels_workspace_channel_idx").on(table.workspaceId, table.channelId),
+]);
+
+// --- Members ---
+
+export const members = sqliteTable("members", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  channelConfigId: integer("channel_config_id")
+    .notNull()
+    .references(() => channels.id, { onDelete: "cascade" }),
+  userId: text("user_id").notNull(),
+  displayName: text("display_name").notNull(),
+  timezone: text("timezone").default("UTC"),
+  isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+  isPaused: integer("is_paused", { mode: "boolean" }).notNull().default(false),
+  joinedAt: integer("joined_at", { mode: "timestamp_ms" }).notNull(),
+}, (table) => [
+  uniqueIndex("members_channel_user_idx").on(table.channelConfigId, table.userId),
+]);
+
+// --- Rounds ---
+
+export const rounds = sqliteTable("rounds", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  channelConfigId: integer("channel_config_id")
+    .notNull()
+    .references(() => channels.id, { onDelete: "cascade" }),
+  executedAt: integer("executed_at", { mode: "timestamp_ms" }).notNull(),
+  groupCount: integer("group_count").notNull(),
+});
+
+// --- Pairings (groups within a round) ---
+
+export const pairings = sqliteTable("pairings", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  roundId: integer("round_id")
+    .notNull()
+    .references(() => rounds.id, { onDelete: "cascade" }),
+  groupIndex: integer("group_index").notNull(),
+});
+
+// --- Pairing Members (junction table) ---
+
+export const pairingMembers = sqliteTable("pairing_members", {
+  pairingId: integer("pairing_id")
+    .notNull()
+    .references(() => pairings.id, { onDelete: "cascade" }),
+  userId: text("user_id").notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.pairingId, table.userId] }),
+]);

--- a/donut/src/env.ts
+++ b/donut/src/env.ts
@@ -1,0 +1,18 @@
+const requiredEnv = (key: string): string => {
+  const value = Bun.env[key];
+  if (!value) throw new Error(`Missing required env var: ${key}`);
+  return value;
+};
+
+export const env = {
+  slack: {
+    botToken: requiredEnv("SLACK_BOT_TOKEN"),
+    signingSecret: requiredEnv("SLACK_SIGNING_SECRET"),
+    clientId: requiredEnv("SLACK_CLIENT_ID"),
+    clientSecret: requiredEnv("SLACK_CLIENT_SECRET"),
+    stateSecret: Bun.env.SLACK_STATE_SECRET ?? "donut-state-secret",
+  },
+  port: Number(Bun.env.PORT ?? 3000),
+  host: Bun.env.HOST ?? "0.0.0.0",
+  databaseUrl: Bun.env.DATABASE_URL ?? "./donut.db",
+} as const;

--- a/donut/src/index.ts
+++ b/donut/src/index.ts
@@ -1,0 +1,38 @@
+import { Hono } from "hono";
+import { logger } from "hono/logger";
+import { env } from "./env";
+import { registerSlackRoutes } from "./slack/app";
+import { registerCommands } from "./slack/commands";
+import { registerEvents } from "./slack/events";
+import { startScheduler, stopScheduler } from "./pairing/scheduler";
+
+const app = new Hono();
+
+// Middleware
+app.use(logger());
+
+// Health check
+app.get("/", (c) => c.json({ status: "ok", app: "donut", version: "0.0.1" }));
+
+// Slack routes (events, commands, interactions, OAuth)
+registerSlackRoutes(app);
+registerCommands();
+registerEvents();
+
+// Start cron scheduler for recurring pairing rounds
+startScheduler().catch((err) => console.error("[startup] Scheduler failed:", err));
+
+// Graceful shutdown
+process.on("SIGINT", () => {
+  console.log("Shutting down...");
+  stopScheduler();
+  process.exit(0);
+});
+
+console.log(`Donut starting on ${env.host}:${env.port}`);
+
+export default {
+  port: env.port,
+  hostname: env.host,
+  fetch: app.fetch,
+};

--- a/donut/src/pairing/engine.ts
+++ b/donut/src/pairing/engine.ts
@@ -1,0 +1,184 @@
+import { getRecentPairings } from "./history";
+
+type PairKey = `${string}:${string}`;
+
+function makePairKey(a: string, b: string): PairKey {
+  return a < b ? `${a}:${b}` : `${b}:${a}`;
+}
+
+type Member = {
+  userId: string;
+  timezone: string | null;
+};
+
+type PairingOptions = {
+  channelConfigId: number;
+  members: Member[];
+  groupSize: number;
+  cooldownRounds: number;
+  timezoneMode: boolean;
+};
+
+// Compute a weight for pairing two users based on history.
+// Higher weight = more desirable to pair.
+// Returns 0 if within cooldown (forbidden).
+function pairWeight(
+  a: string,
+  b: string,
+  history: Map<PairKey, number>,
+  cooldownRounds: number,
+): number {
+  const key = makePairKey(a, b);
+  const roundsAgo = history.get(key);
+
+  if (roundsAgo === undefined) return 100; // never paired = max weight
+  if (roundsAgo <= cooldownRounds) return 0; // within cooldown = forbidden
+  return roundsAgo * 10; // older pairings get higher weight
+}
+
+// Weighted random pick from an array with weights
+function weightedPick<T>(items: T[], weights: number[]): number {
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  if (total === 0) return Math.floor(Math.random() * items.length); // fallback to uniform
+
+  let r = Math.random() * total;
+  for (let i = 0; i < weights.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return i;
+  }
+  return items.length - 1;
+}
+
+// Fisher-Yates shuffle
+function shuffle<T>(arr: T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+// Group members by timezone bucket (±2hr tolerance)
+function groupByTimezone(members: Member[]): Member[][] {
+  const buckets = new Map<number, Member[]>();
+
+  for (const member of members) {
+    const offset = getUtcOffsetHours(member.timezone ?? "UTC");
+    // Round to nearest 2-hour bucket
+    const bucket = Math.round(offset / 2) * 2;
+    const existing = buckets.get(bucket) ?? [];
+    existing.push(member);
+    buckets.set(bucket, existing);
+  }
+
+  // Sort buckets by offset
+  const sorted = [...buckets.entries()].sort((a, b) => a[0] - b[0]);
+  return sorted.map(([, members]) => members);
+}
+
+function getUtcOffsetHours(timezone: string): number {
+  try {
+    const now = new Date();
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    });
+    const parts = formatter.formatToParts(now);
+    const tzPart = parts.find((p) => p.type === "timeZoneName");
+    if (!tzPart) return 0;
+
+    // Format is like "GMT+5" or "GMT-8" or "GMT+5:30"
+    const match = tzPart.value.match(/GMT([+-])(\d+)(?::(\d+))?/);
+    if (!match) return 0;
+
+    const sign = match[1] === "+" ? 1 : -1;
+    const hours = parseInt(match[2], 10);
+    const minutes = match[3] ? parseInt(match[3], 10) : 0;
+    return sign * (hours + minutes / 60);
+  } catch {
+    return 0;
+  }
+}
+
+// Core pairing algorithm
+// Returns groups of user IDs
+export async function generatePairings(options: PairingOptions): Promise<string[][]> {
+  const { channelConfigId, members, groupSize, cooldownRounds, timezoneMode } = options;
+
+  if (members.length < 2) return [];
+  if (members.length <= groupSize) return [members.map((m) => m.userId)];
+
+  const history = await getRecentPairings(channelConfigId, cooldownRounds);
+
+  let memberPool: Member[];
+  if (timezoneMode) {
+    // Group by timezone, then flatten — this keeps tz-similar people adjacent
+    // so the greedy group-forming picks them together
+    const tzGroups = groupByTimezone(members);
+    memberPool = tzGroups.flatMap((group) => shuffle(group));
+  } else {
+    memberPool = shuffle(members);
+  }
+
+  const groups: string[][] = [];
+  const assigned = new Set<string>();
+
+  // Greedily form groups
+  while (assigned.size < memberPool.length) {
+    const remaining = memberPool.filter((m) => !assigned.has(m.userId));
+    if (remaining.length === 0) break;
+
+    // If remaining < groupSize, distribute into existing groups
+    if (remaining.length < groupSize && groups.length > 0) {
+      for (const member of remaining) {
+        // Find the group where this member has the best average weight
+        let bestGroupIdx = 0;
+        let bestWeight = -1;
+
+        for (let g = 0; g < groups.length; g++) {
+          const avgWeight =
+            groups[g].reduce((sum, uid) => sum + pairWeight(member.userId, uid, history, cooldownRounds), 0) /
+            groups[g].length;
+          if (avgWeight > bestWeight) {
+            bestWeight = avgWeight;
+            bestGroupIdx = g;
+          }
+        }
+
+        groups[bestGroupIdx].push(member.userId);
+        assigned.add(member.userId);
+      }
+      break;
+    }
+
+    // Start a new group with the first unassigned member
+    const seed = remaining[0];
+    const group: string[] = [seed.userId];
+    assigned.add(seed.userId);
+
+    // Greedily add members with highest weight to current group
+    while (group.length < groupSize) {
+      const candidates = memberPool.filter((m) => !assigned.has(m.userId));
+      if (candidates.length === 0) break;
+
+      const weights = candidates.map((candidate) => {
+        // Average weight across all current group members
+        const total = group.reduce(
+          (sum, uid) => sum + pairWeight(candidate.userId, uid, history, cooldownRounds),
+          0,
+        );
+        return total / group.length;
+      });
+
+      const pickedIdx = weightedPick(candidates, weights);
+      const picked = candidates[pickedIdx];
+      group.push(picked.userId);
+      assigned.add(picked.userId);
+    }
+
+    groups.push(group);
+  }
+
+  return groups;
+}

--- a/donut/src/pairing/history.ts
+++ b/donut/src/pairing/history.ts
@@ -1,0 +1,96 @@
+import { eq, desc } from "drizzle-orm";
+import { db } from "../db/client";
+import { rounds, pairings, pairingMembers } from "../db/schema";
+
+type PairKey = `${string}:${string}`;
+
+function makePairKey(a: string, b: string): PairKey {
+  return a < b ? `${a}:${b}` : `${b}:${a}`;
+}
+
+// Returns a map of pair keys to how many rounds ago they were last paired.
+// Only looks back `cooldownRounds` rounds for the given channel config.
+export async function getRecentPairings(
+  channelConfigId: number,
+  cooldownRounds: number,
+): Promise<Map<PairKey, number>> {
+  const recentRounds = await db
+    .select({ id: rounds.id })
+    .from(rounds)
+    .where(eq(rounds.channelConfigId, channelConfigId))
+    .orderBy(desc(rounds.executedAt))
+    .limit(cooldownRounds);
+
+  if (recentRounds.length === 0) return new Map();
+
+  const roundIds = recentRounds.map((r) => r.id);
+  const pairHistory = new Map<PairKey, number>();
+
+  for (let i = 0; i < roundIds.length; i++) {
+    const roundId = roundIds[i];
+    const roundsAgo = i + 1;
+
+    // Get all pairings in this round
+    const groups = await db
+      .select({ pairingId: pairings.id })
+      .from(pairings)
+      .where(eq(pairings.roundId, roundId));
+
+    for (const group of groups) {
+      // Get members in this pairing group
+      const groupMembers = await db
+        .select({ userId: pairingMembers.userId })
+        .from(pairingMembers)
+        .where(eq(pairingMembers.pairingId, group.pairingId));
+
+      const userIds = groupMembers.map((m) => m.userId);
+
+      // Generate all pairs within this group
+      for (let a = 0; a < userIds.length; a++) {
+        for (let b = a + 1; b < userIds.length; b++) {
+          const key = makePairKey(userIds[a], userIds[b]);
+          // Keep the most recent (smallest roundsAgo) occurrence
+          if (!pairHistory.has(key)) {
+            pairHistory.set(key, roundsAgo);
+          }
+        }
+      }
+    }
+  }
+
+  return pairHistory;
+}
+
+// Record a completed round and its pairing groups
+export async function recordRound(
+  channelConfigId: number,
+  groups: string[][],
+): Promise<number> {
+  const [round] = await db
+    .insert(rounds)
+    .values({
+      channelConfigId,
+      executedAt: new Date(),
+      groupCount: groups.length,
+    })
+    .returning({ id: rounds.id });
+
+  for (let i = 0; i < groups.length; i++) {
+    const [pairing] = await db
+      .insert(pairings)
+      .values({
+        roundId: round.id,
+        groupIndex: i,
+      })
+      .returning({ id: pairings.id });
+
+    const memberRows = groups[i].map((userId) => ({
+      pairingId: pairing.id,
+      userId,
+    }));
+
+    await db.insert(pairingMembers).values(memberRows);
+  }
+
+  return round.id;
+}

--- a/donut/src/pairing/scheduler.ts
+++ b/donut/src/pairing/scheduler.ts
@@ -1,0 +1,104 @@
+import { Cron } from "croner";
+import { eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { channels, workspaces } from "../db/schema";
+import { executePairingRound } from "../slack/commands";
+
+// Active cron jobs keyed by channel config ID
+const activeJobs = new Map<number, Cron>();
+
+// Schedule a pairing round for a specific channel config
+function scheduleChannel(config: {
+  id: number;
+  channelId: string;
+  frequency: string;
+  timezone: string;
+  workspaceId: string;
+}): void {
+  // Cancel existing job if any
+  const existing = activeJobs.get(config.id);
+  if (existing) existing.stop();
+
+  const job = new Cron(config.frequency, { timezone: config.timezone }, async () => {
+    console.log(`[scheduler] Running pairing round for channel ${config.channelId}`);
+
+    // Fetch fresh bot token
+    const [workspace] = await db
+      .select({ botToken: workspaces.botToken })
+      .from(workspaces)
+      .where(eq(workspaces.id, config.workspaceId))
+      .limit(1);
+
+    if (!workspace) {
+      console.error(`[scheduler] No workspace found for ${config.workspaceId}`);
+      return;
+    }
+
+    const result = await executePairingRound(config.id, config.channelId, workspace.botToken);
+    if ("error" in result) {
+      console.error(`[scheduler] Pairing failed for ${config.channelId}: ${result.error}`);
+    } else {
+      console.log(`[scheduler] Paired ${result.groupCount} groups in ${config.channelId}`);
+    }
+  });
+
+  activeJobs.set(config.id, job);
+  const next = job.nextRun();
+  console.log(`[scheduler] Scheduled channel ${config.channelId} (${config.frequency} ${config.timezone}), next: ${next?.toISOString() ?? "unknown"}`);
+}
+
+// Load all active channel configs and schedule them
+export async function startScheduler(): Promise<void> {
+  const activeChannels = await db
+    .select()
+    .from(channels)
+    .where(eq(channels.isActive, true));
+
+  console.log(`[scheduler] Loading ${activeChannels.length} active channel(s)`);
+
+  for (const config of activeChannels) {
+    scheduleChannel({
+      id: config.id,
+      channelId: config.channelId,
+      frequency: config.frequency,
+      timezone: config.timezone,
+      workspaceId: config.workspaceId,
+    });
+  }
+}
+
+// Reschedule a specific channel (call after config update)
+export async function rescheduleChannel(channelConfigId: number): Promise<void> {
+  const [config] = await db
+    .select()
+    .from(channels)
+    .where(eq(channels.id, channelConfigId))
+    .limit(1);
+
+  if (!config || !config.isActive) {
+    // Remove existing job if channel was deactivated
+    const existing = activeJobs.get(channelConfigId);
+    if (existing) {
+      existing.stop();
+      activeJobs.delete(channelConfigId);
+    }
+    return;
+  }
+
+  scheduleChannel({
+    id: config.id,
+    channelId: config.channelId,
+    frequency: config.frequency,
+    timezone: config.timezone,
+    workspaceId: config.workspaceId,
+  });
+}
+
+// Stop all scheduled jobs (for graceful shutdown)
+export function stopScheduler(): void {
+  for (const [id, job] of activeJobs) {
+    job.stop();
+    activeJobs.delete(id);
+  }
+  console.log("[scheduler] All jobs stopped");
+}

--- a/donut/src/slack/app.ts
+++ b/donut/src/slack/app.ts
@@ -1,0 +1,129 @@
+import { App, type Receiver, type ReceiverEvent } from "@slack/bolt";
+import type AppType from "@slack/bolt/dist/App";
+import { Hono } from "hono";
+import { env } from "../env";
+
+// Custom receiver that bridges Slack Bolt events through Hono.
+// Instead of Bolt managing its own HTTP server, we parse Slack payloads
+// in Hono routes and dispatch them to Bolt's event handlers.
+
+type BoltEventHandler = (event: ReceiverEvent) => Promise<void>;
+
+let boltEventHandler: BoltEventHandler | undefined;
+
+const honoReceiver: Receiver = {
+  init(app: AppType) {
+    boltEventHandler = app.processEvent.bind(app);
+  },
+  start: async () => {},
+  stop: async () => {},
+};
+
+export const slackApp = new App({
+  token: env.slack.botToken,
+  signingSecret: env.slack.signingSecret,
+  receiver: honoReceiver,
+});
+
+// Dispatch a parsed Slack event through Bolt's handler pipeline
+export async function dispatchSlackEvent(body: Record<string, unknown>, ack: () => Promise<void>): Promise<void> {
+  if (!boltEventHandler) {
+    throw new Error("Bolt event handler not initialized");
+  }
+  await boltEventHandler({
+    body,
+    ack: ack as ReceiverEvent["ack"],
+  });
+}
+
+// Register Slack-specific routes on a Hono app
+export function registerSlackRoutes(hono: Hono): void {
+  // Slack sends URL verification challenges and events to this endpoint
+  hono.post("/slack/events", async (c) => {
+    const body = await c.req.json();
+
+    // Handle URL verification challenge
+    if (body.type === "url_verification") {
+      return c.json({ challenge: body.challenge });
+    }
+
+    // Dispatch to Bolt
+    let ackCalled = false;
+    let ackBody: unknown = undefined;
+    await dispatchSlackEvent(body, async () => {
+      ackCalled = true;
+    });
+
+    if (ackCalled) {
+      return ackBody ? c.json(ackBody) : c.text("");
+    }
+    return c.text("");
+  });
+
+  // Slack slash commands
+  hono.post("/slack/commands", async (c) => {
+    const formData = await c.req.parseBody();
+    const body = {
+      ...formData,
+      type: "slash_command",
+    };
+
+    let ackBody: unknown = undefined;
+    await dispatchSlackEvent(body as Record<string, unknown>, async () => {
+      ackBody = undefined;
+    });
+
+    return ackBody ? c.json(ackBody) : c.text("");
+  });
+
+  // Slack interactive components (modals, buttons, etc.)
+  hono.post("/slack/interactions", async (c) => {
+    const formData = await c.req.parseBody();
+    const payloadStr = formData.payload;
+    if (typeof payloadStr !== "string") {
+      return c.text("Invalid payload", 400);
+    }
+    const body = JSON.parse(payloadStr);
+
+    let ackBody: unknown = undefined;
+    await dispatchSlackEvent(body, async () => {
+      ackBody = undefined;
+    });
+
+    return ackBody ? c.json(ackBody) : c.text("");
+  });
+
+  // OAuth install redirect
+  hono.get("/slack/install", (c) => {
+    const scopes = "chat:write,commands,users:read,channels:read,groups:read,im:write";
+    const url = `https://slack.com/oauth/v2/authorize?client_id=${env.slack.clientId}&scope=${scopes}&redirect_uri=${encodeURIComponent(`${c.req.url.replace("/slack/install", "/slack/oauth_redirect")}`)}`;
+    return c.redirect(url);
+  });
+
+  // OAuth callback
+  hono.get("/slack/oauth_redirect", async (c) => {
+    const code = c.req.query("code");
+    if (!code) return c.text("Missing code parameter", 400);
+
+    try {
+      const result = await slackApp.client.oauth.v2.access({
+        client_id: env.slack.clientId,
+        client_secret: env.slack.clientSecret,
+        code,
+      });
+
+      if (!result.ok) {
+        return c.text("OAuth failed", 500);
+      }
+
+      // Store workspace credentials — will be handled by the install callback
+      // For now, log success
+      console.log(`Workspace installed: ${result.team?.name} (${result.team?.id})`);
+
+      return c.html("<html><body><h1>Donut installed!</h1><p>You can close this tab.</p></body></html>");
+    } catch (err) {
+      console.error("OAuth error:", err);
+      return c.text("OAuth error", 500);
+    }
+  });
+}

--- a/donut/src/slack/commands.ts
+++ b/donut/src/slack/commands.ts
@@ -1,0 +1,378 @@
+import { eq, and } from "drizzle-orm";
+import type { KnownBlock } from "@slack/types";
+import { slackApp } from "./app";
+import { db } from "../db/client";
+import { channels, members } from "../db/schema";
+import { generatePairings } from "../pairing/engine";
+import { recordRound } from "../pairing/history";
+import { configModal, parseConfigModalValues } from "./modals";
+import {
+  pairingDmBlocks,
+  roundAnnouncementBlocks,
+  joinConfirmation,
+  leaveConfirmation,
+  pauseConfirmation,
+  resumeConfirmation,
+  statusMessage,
+  alreadySetup,
+  notSetup,
+  notEnoughMembers,
+  triggerSuccess,
+} from "./messages";
+
+// Parse subcommand from slash command text
+function parseSubcommand(text: string): { subcommand: string; args: string } {
+  const trimmed = text.trim();
+  const spaceIdx = trimmed.indexOf(" ");
+  if (spaceIdx === -1) return { subcommand: trimmed.toLowerCase(), args: "" };
+  return {
+    subcommand: trimmed.slice(0, spaceIdx).toLowerCase(),
+    args: trimmed.slice(spaceIdx + 1).trim(),
+  };
+}
+
+// Get or return null for channel config
+async function getChannelConfig(workspaceId: string, channelId: string) {
+  const [config] = await db
+    .select()
+    .from(channels)
+    .where(and(eq(channels.workspaceId, workspaceId), eq(channels.channelId, channelId)))
+    .limit(1);
+  return config ?? null;
+}
+
+// Get active member count for a channel config
+async function getActiveMemberCount(channelConfigId: number): Promise<number> {
+  const result = await db
+    .select()
+    .from(members)
+    .where(and(eq(members.channelConfigId, channelConfigId), eq(members.isActive, true)));
+  return result.length;
+}
+
+// Execute a pairing round for a channel
+export async function executePairingRound(
+  channelConfigId: number,
+  channelId: string,
+  botToken: string,
+): Promise<{ groupCount: number } | { error: string }> {
+  const [config] = await db
+    .select()
+    .from(channels)
+    .where(eq(channels.id, channelConfigId))
+    .limit(1);
+
+  if (!config) return { error: "Channel config not found" };
+
+  const activeMembers = await db
+    .select()
+    .from(members)
+    .where(
+      and(
+        eq(members.channelConfigId, channelConfigId),
+        eq(members.isActive, true),
+        eq(members.isPaused, false),
+      ),
+    );
+
+  if (activeMembers.length < 2) return { error: "Not enough members" };
+
+  const groups = await generatePairings({
+    channelConfigId,
+    members: activeMembers.map((m) => ({ userId: m.userId, timezone: m.timezone })),
+    groupSize: config.groupSize,
+    cooldownRounds: config.cooldownRounds,
+    timezoneMode: config.timezoneMode,
+  });
+
+  if (groups.length === 0) return { error: "Could not form any groups" };
+
+  // Record the round
+  await recordRound(channelConfigId, groups);
+
+  // Send DMs to each group
+  for (const group of groups) {
+    // Open a multi-person DM
+    try {
+      const conversation = await slackApp.client.conversations.open({
+        token: botToken,
+        users: group.join(","),
+      });
+
+      if (conversation.channel?.id) {
+        await slackApp.client.chat.postMessage({
+          token: botToken,
+          channel: conversation.channel.id,
+          blocks: pairingDmBlocks(group) as KnownBlock[],
+          text: `You've been paired for a coffee chat! Meet: ${group.map((u) => `<@${u}>`).join(", ")}`,
+        });
+      }
+    } catch (err) {
+      console.error(`Failed to DM group [${group.join(", ")}]:`, err);
+    }
+  }
+
+  // Post channel announcement
+  try {
+    await slackApp.client.chat.postMessage({
+      token: botToken,
+      channel: channelId,
+      blocks: roundAnnouncementBlocks(groups.length, config.groupSize) as KnownBlock[],
+      text: `A new Donut round just ran! ${groups.length} groups paired.`,
+    });
+  } catch (err) {
+    console.error("Failed to post channel announcement:", err);
+  }
+
+  return { groupCount: groups.length };
+}
+
+// Register the /donut slash command
+export function registerCommands(): void {
+  slackApp.command("/donut", async ({ command, ack, respond, client }) => {
+    const { subcommand } = parseSubcommand(command.text);
+    const workspaceId = command.team_id;
+    const channelId = command.channel_id;
+    const userId = command.user_id;
+
+    switch (subcommand) {
+      case "setup": {
+        await ack();
+        const existing = await getChannelConfig(workspaceId, channelId);
+        if (existing) {
+          await respond({ text: alreadySetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        // Create channel config with defaults
+        const [newConfig] = await db
+          .insert(channels)
+          .values({
+            workspaceId,
+            channelId,
+            channelName: command.channel_name,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .returning();
+
+        // Open config modal
+        await client.views.open({
+          trigger_id: command.trigger_id,
+          view: configModal(channelId, {
+            groupSize: newConfig.groupSize,
+            frequency: newConfig.frequency,
+            timezone: newConfig.timezone,
+            cooldownRounds: newConfig.cooldownRounds,
+            timezoneMode: newConfig.timezoneMode,
+          }) as Parameters<typeof client.views.open>[0]["view"],
+        });
+        break;
+      }
+
+      case "join": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        // Get user info for display name and timezone
+        const userInfo = await client.users.info({ user: userId });
+        const displayName = userInfo.user?.real_name ?? userInfo.user?.name ?? userId;
+        const userTz = userInfo.user?.tz ?? "UTC";
+
+        // Upsert member
+        const existingMember = await db
+          .select()
+          .from(members)
+          .where(and(eq(members.channelConfigId, config.id), eq(members.userId, userId)))
+          .limit(1);
+
+        if (existingMember.length > 0) {
+          await db
+            .update(members)
+            .set({ isActive: true, isPaused: false, displayName, timezone: userTz })
+            .where(eq(members.id, existingMember[0].id));
+        } else {
+          await db.insert(members).values({
+            channelConfigId: config.id,
+            userId,
+            displayName,
+            timezone: userTz,
+            joinedAt: new Date(),
+          });
+        }
+
+        await respond({ text: joinConfirmation(channelId), response_type: "ephemeral" });
+        break;
+      }
+
+      case "leave": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        await db
+          .update(members)
+          .set({ isActive: false })
+          .where(and(eq(members.channelConfigId, config.id), eq(members.userId, userId)));
+
+        await respond({ text: leaveConfirmation(channelId), response_type: "ephemeral" });
+        break;
+      }
+
+      case "pause": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        await db
+          .update(members)
+          .set({ isPaused: true })
+          .where(and(eq(members.channelConfigId, config.id), eq(members.userId, userId)));
+
+        await respond({ text: pauseConfirmation(channelId), response_type: "ephemeral" });
+        break;
+      }
+
+      case "resume": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        await db
+          .update(members)
+          .set({ isPaused: false })
+          .where(and(eq(members.channelConfigId, config.id), eq(members.userId, userId)));
+
+        await respond({ text: resumeConfirmation(channelId), response_type: "ephemeral" });
+        break;
+      }
+
+      case "config": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        await client.views.open({
+          trigger_id: command.trigger_id,
+          view: configModal(channelId, {
+            groupSize: config.groupSize,
+            frequency: config.frequency,
+            timezone: config.timezone,
+            cooldownRounds: config.cooldownRounds,
+            timezoneMode: config.timezoneMode,
+          }) as Parameters<typeof client.views.open>[0]["view"],
+        });
+        break;
+      }
+
+      case "status": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        const memberCount = await getActiveMemberCount(config.id);
+
+        await respond({
+          blocks: statusMessage({
+            channelId,
+            groupSize: config.groupSize,
+            frequency: config.frequency,
+            timezone: config.timezone,
+            cooldownRounds: config.cooldownRounds,
+            timezoneMode: config.timezoneMode,
+            memberCount,
+            isActive: config.isActive,
+          }) as KnownBlock[],
+          response_type: "ephemeral",
+        });
+        break;
+      }
+
+      case "trigger": {
+        await ack();
+        const config = await getChannelConfig(workspaceId, channelId);
+        if (!config) {
+          await respond({ text: notSetup(channelId), response_type: "ephemeral" });
+          return;
+        }
+
+        const memberCount = await getActiveMemberCount(config.id);
+        if (memberCount < 2) {
+          await respond({ text: notEnoughMembers(), response_type: "ephemeral" });
+          return;
+        }
+
+        // Find workspace bot token
+        const result = await executePairingRound(config.id, channelId, command.token);
+        if ("error" in result) {
+          await respond({ text: `:x: ${result.error}`, response_type: "ephemeral" });
+          return;
+        }
+
+        await respond({ text: triggerSuccess(result.groupCount), response_type: "ephemeral" });
+        break;
+      }
+
+      default: {
+        await ack();
+        await respond({
+          text: [
+            ":doughnut: *Donut Commands:*",
+            "`/donut setup` — Enable Donut in this channel",
+            "`/donut join` — Join the pairing pool",
+            "`/donut leave` — Leave the pairing pool",
+            "`/donut pause` — Skip upcoming rounds",
+            "`/donut resume` — Unpause yourself",
+            "`/donut config` — Configure settings (admin)",
+            "`/donut status` — View current config & stats",
+            "`/donut trigger` — Run a pairing round now (admin)",
+          ].join("\n"),
+          response_type: "ephemeral",
+        });
+      }
+    }
+  });
+
+  // Handle config modal submission
+  slackApp.view("donut_config_modal", async ({ ack, view, body }) => {
+    await ack();
+
+    const channelId = view.private_metadata;
+    const config = parseConfigModalValues(
+      view.state.values as Parameters<typeof parseConfigModalValues>[0],
+    );
+    const workspaceId = body.team?.id;
+    if (!workspaceId) return;
+
+    await db
+      .update(channels)
+      .set({
+        groupSize: config.groupSize,
+        frequency: config.frequency,
+        timezone: config.timezone,
+        cooldownRounds: config.cooldownRounds,
+        timezoneMode: config.timezoneMode,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(channels.workspaceId, workspaceId), eq(channels.channelId, channelId)));
+  });
+}

--- a/donut/src/slack/events.ts
+++ b/donut/src/slack/events.ts
@@ -1,0 +1,99 @@
+import { eq } from "drizzle-orm";
+import { slackApp } from "./app";
+import { db } from "../db/client";
+import { channels, members } from "../db/schema";
+
+export function registerEvents(): void {
+  // App Home opened — show user their Donut status
+  slackApp.event("app_home_opened", async ({ event, client }) => {
+    const userId = event.user;
+
+    // Find all channels this user is a member of
+    const userMemberships = await db
+      .select({
+        channelId: channels.channelId,
+        channelName: channels.channelName,
+        isActive: members.isActive,
+        isPaused: members.isPaused,
+      })
+      .from(members)
+      .innerJoin(channels, eq(members.channelConfigId, channels.id))
+      .where(eq(members.userId, userId));
+
+    const blocks: object[] = [
+      {
+        type: "header",
+        text: { type: "plain_text", text: ":doughnut: Donut" },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Welcome to Donut! Get randomly paired with teammates for coffee chats.",
+        },
+      },
+      { type: "divider" },
+    ];
+
+    if (userMemberships.length === 0) {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "You haven't joined Donut in any channels yet. Use `/donut join` in a channel that has Donut set up.",
+        },
+      });
+    } else {
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: "*Your Channels:*" },
+      });
+
+      for (const membership of userMemberships) {
+        const statusEmoji = membership.isPaused
+          ? ":pause_button:"
+          : membership.isActive
+            ? ":large_green_circle:"
+            : ":red_circle:";
+        const statusText = membership.isPaused
+          ? "Paused"
+          : membership.isActive
+            ? "Active"
+            : "Opted out";
+
+        blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `${statusEmoji} <#${membership.channelId}> — ${statusText}`,
+          },
+        });
+      }
+    }
+
+    blocks.push(
+      { type: "divider" },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "Commands: `/donut join` · `/donut leave` · `/donut pause` · `/donut resume` · `/donut status`",
+          },
+        ],
+      },
+    );
+
+    try {
+      await client.views.publish({
+        user_id: userId,
+        view: {
+          type: "home",
+          blocks: blocks as Parameters<typeof client.views.publish>[0]["view"]["blocks"],
+        },
+      });
+    } catch (err) {
+      console.error("Failed to publish App Home:", err);
+    }
+  });
+}

--- a/donut/src/slack/messages.ts
+++ b/donut/src/slack/messages.ts
@@ -1,0 +1,117 @@
+// Slack Block Kit message templates for Donut notifications
+
+export function pairingDmBlocks(groupMembers: string[]): object[] {
+  const mentions = groupMembers.map((uid) => `<@${uid}>`).join(", ");
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:doughnut: *You've been paired for a coffee chat!*\n\nMeet: ${mentions}`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Find a time that works for everyone and grab coffee (or tea, or a walk). Have fun!",
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "_Powered by Donut_",
+        },
+      ],
+    },
+  ];
+}
+
+export function roundAnnouncementBlocks(
+  groupCount: number,
+  groupSize: number,
+): object[] {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:doughnut: *A new Donut round just ran!*\n\n${groupCount} groups of ~${groupSize} have been paired. Check your DMs!`,
+      },
+    },
+  ];
+}
+
+export function joinConfirmation(channelId: string): string {
+  return `:white_check_mark: You've joined Donut in <#${channelId}>! You'll be included in the next pairing round.`;
+}
+
+export function leaveConfirmation(channelId: string): string {
+  return `You've left Donut in <#${channelId}>. You won't be included in future pairings.`;
+}
+
+export function pauseConfirmation(channelId: string): string {
+  return `:pause_button: You're paused in <#${channelId}>. Use \`/donut resume\` when you're ready to come back.`;
+}
+
+export function resumeConfirmation(channelId: string): string {
+  return `:arrow_forward: You're back! You'll be included in the next Donut round in <#${channelId}>.`;
+}
+
+export function statusMessage(config: {
+  channelId: string;
+  groupSize: number;
+  frequency: string;
+  timezone: string;
+  cooldownRounds: number;
+  timezoneMode: boolean;
+  memberCount: number;
+  isActive: boolean;
+}): object[] {
+  const statusEmoji = config.isActive ? ":large_green_circle:" : ":red_circle:";
+  const tzMode = config.timezoneMode ? "On" : "Off";
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:doughnut: *Donut Status for <#${config.channelId}>*`,
+      },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Status:* ${statusEmoji} ${config.isActive ? "Active" : "Paused"}` },
+        { type: "mrkdwn", text: `*Group Size:* ${config.groupSize}` },
+        { type: "mrkdwn", text: `*Schedule:* \`${config.frequency}\`` },
+        { type: "mrkdwn", text: `*Timezone:* ${config.timezone}` },
+        { type: "mrkdwn", text: `*Cooldown:* ${config.cooldownRounds} rounds` },
+        { type: "mrkdwn", text: `*TZ Pairing:* ${tzMode}` },
+        { type: "mrkdwn", text: `*Members:* ${config.memberCount}` },
+      ],
+    },
+  ];
+}
+
+export function setupConfirmation(channelId: string): string {
+  return `:white_check_mark: Donut is now set up in <#${channelId}>! Members can join with \`/donut join\`.`;
+}
+
+export function alreadySetup(channelId: string): string {
+  return `Donut is already set up in <#${channelId}>. Use \`/donut config\` to change settings.`;
+}
+
+export function notSetup(channelId: string): string {
+  return `Donut isn't set up in <#${channelId}> yet. An admin can run \`/donut setup\` to get started.`;
+}
+
+export function notEnoughMembers(): string {
+  return "Not enough members to form a group. At least 2 members need to join first!";
+}
+
+export function triggerSuccess(groupCount: number): string {
+  return `:doughnut: Done! ${groupCount} groups have been paired. Check your DMs!`;
+}

--- a/donut/src/slack/modals.ts
+++ b/donut/src/slack/modals.ts
@@ -1,0 +1,159 @@
+// Slack modal views for Donut configuration
+
+type ChannelConfig = {
+  groupSize: number;
+  frequency: string;
+  timezone: string;
+  cooldownRounds: number;
+  timezoneMode: boolean;
+};
+
+const FREQUENCY_OPTIONS = [
+  { text: "Weekly - Monday", value: "0 10 * * 1" },
+  { text: "Weekly - Tuesday", value: "0 10 * * 2" },
+  { text: "Weekly - Wednesday", value: "0 10 * * 3" },
+  { text: "Weekly - Thursday", value: "0 10 * * 4" },
+  { text: "Weekly - Friday", value: "0 10 * * 5" },
+  { text: "Biweekly - Monday", value: "0 10 1-7,15-21 * 1" },
+  { text: "Monthly - 1st Monday", value: "0 10 1-7 * 1" },
+];
+
+const COMMON_TIMEZONES = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Toronto",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Kolkata",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+  "UTC",
+];
+
+export function configModal(
+  channelId: string,
+  existing?: ChannelConfig,
+): object {
+  const defaults: ChannelConfig = existing ?? {
+    groupSize: 3,
+    frequency: "0 10 * * 1",
+    timezone: "America/New_York",
+    cooldownRounds: 3,
+    timezoneMode: false,
+  };
+
+  return {
+    type: "modal",
+    callback_id: "donut_config_modal",
+    private_metadata: channelId,
+    title: { type: "plain_text", text: "Donut Config" },
+    submit: { type: "plain_text", text: "Save" },
+    close: { type: "plain_text", text: "Cancel" },
+    blocks: [
+      {
+        type: "input",
+        block_id: "group_size",
+        label: { type: "plain_text", text: "Group Size" },
+        element: {
+          type: "number_input",
+          action_id: "group_size_input",
+          is_decimal_allowed: false,
+          min_value: "2",
+          max_value: "8",
+          initial_value: String(defaults.groupSize),
+          placeholder: { type: "plain_text", text: "How many people per group?" },
+        },
+      },
+      {
+        type: "input",
+        block_id: "frequency",
+        label: { type: "plain_text", text: "Frequency" },
+        element: {
+          type: "static_select",
+          action_id: "frequency_select",
+          initial_option: {
+            text: {
+              type: "plain_text",
+              text: FREQUENCY_OPTIONS.find((o) => o.value === defaults.frequency)?.text ?? "Weekly - Monday",
+            },
+            value: defaults.frequency,
+          },
+          options: FREQUENCY_OPTIONS.map((o) => ({
+            text: { type: "plain_text", text: o.text },
+            value: o.value,
+          })),
+        },
+      },
+      {
+        type: "input",
+        block_id: "timezone",
+        label: { type: "plain_text", text: "Schedule Timezone" },
+        element: {
+          type: "static_select",
+          action_id: "timezone_select",
+          initial_option: {
+            text: { type: "plain_text", text: defaults.timezone },
+            value: defaults.timezone,
+          },
+          options: COMMON_TIMEZONES.map((tz) => ({
+            text: { type: "plain_text", text: tz },
+            value: tz,
+          })),
+        },
+      },
+      {
+        type: "input",
+        block_id: "cooldown",
+        label: { type: "plain_text", text: "Cooldown (rounds)" },
+        hint: {
+          type: "plain_text",
+          text: "Prevent re-pairing within this many recent rounds",
+        },
+        element: {
+          type: "number_input",
+          action_id: "cooldown_input",
+          is_decimal_allowed: false,
+          min_value: "0",
+          max_value: "20",
+          initial_value: String(defaults.cooldownRounds),
+        },
+      },
+      {
+        type: "input",
+        block_id: "timezone_mode",
+        label: { type: "plain_text", text: "Timezone-Aware Pairing" },
+        hint: {
+          type: "plain_text",
+          text: "When enabled, prefer grouping people in similar timezones",
+        },
+        element: {
+          type: "static_select",
+          action_id: "timezone_mode_select",
+          initial_option: defaults.timezoneMode
+            ? { text: { type: "plain_text", text: "On" }, value: "true" }
+            : { text: { type: "plain_text", text: "Off" }, value: "false" },
+          options: [
+            { text: { type: "plain_text", text: "On" }, value: "true" },
+            { text: { type: "plain_text", text: "Off" }, value: "false" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+// Extract values from a submitted config modal
+export function parseConfigModalValues(values: Record<string, Record<string, { value?: string; selected_option?: { value: string } }>>): ChannelConfig {
+  return {
+    groupSize: parseInt(values.group_size.group_size_input.value ?? "3", 10),
+    frequency: values.frequency.frequency_select.selected_option?.value ?? "0 10 * * 1",
+    timezone: values.timezone.timezone_select.selected_option?.value ?? "America/New_York",
+    cooldownRounds: parseInt(values.cooldown.cooldown_input.value ?? "3", 10),
+    timezoneMode: values.timezone_mode.timezone_mode_select.selected_option?.value === "true",
+  };
+}

--- a/donut/src/utils/timezone.ts
+++ b/donut/src/utils/timezone.ts
@@ -1,0 +1,52 @@
+// Get the UTC offset in hours for an IANA timezone string
+export function getUtcOffsetHours(timezone: string): number {
+  try {
+    const now = new Date();
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    });
+    const parts = formatter.formatToParts(now);
+    const tzPart = parts.find((p) => p.type === "timeZoneName");
+    if (!tzPart) return 0;
+
+    const match = tzPart.value.match(/GMT([+-])(\d+)(?::(\d+))?/);
+    if (!match) return 0;
+
+    const sign = match[1] === "+" ? 1 : -1;
+    const hours = parseInt(match[2], 10);
+    const minutes = match[3] ? parseInt(match[3], 10) : 0;
+    return sign * (hours + minutes / 60);
+  } catch {
+    return 0;
+  }
+}
+
+// Check if two timezones are within a tolerance of each other (in hours)
+export function timezonesOverlap(
+  tz1: string,
+  tz2: string,
+  toleranceHours = 2,
+): boolean {
+  const offset1 = getUtcOffsetHours(tz1);
+  const offset2 = getUtcOffsetHours(tz2);
+  return Math.abs(offset1 - offset2) <= toleranceHours;
+}
+
+// Group timezone strings into buckets of similar offsets
+export function bucketTimezones(
+  timezones: string[],
+  bucketSizeHours = 2,
+): Map<number, string[]> {
+  const buckets = new Map<number, string[]>();
+
+  for (const tz of timezones) {
+    const offset = getUtcOffsetHours(tz);
+    const bucket = Math.round(offset / bucketSizeHours) * bucketSizeHours;
+    const existing = buckets.get(bucket) ?? [];
+    existing.push(tz);
+    buckets.set(bucket, existing);
+  }
+
+  return buckets;
+}

--- a/donut/tsconfig.json
+++ b/donut/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "drizzle"]
+}


### PR DESCRIPTION
## Summary

Adds `donut/` — a self-hosted alternative to Slack's Donut product for random team member pairing. Scoped as a subdirectory of this dotfiles repo for now, but designed for extraction into its own repo later.

## What changed

- New `donut/` subdirectory with a full Bun + Hono + @slack/bolt + Drizzle ORM (bun:sqlite) + croner stack
- 6-table SQLite schema: `workspaces`, `channels`, `members`, `rounds`, `pairings`, `pairing_members`
- `/donut` slash command with 8 subcommands: `setup`, `join`, `leave`, `pause`, `resume`, `config`, `status`, `trigger`
- Weighted random pairing engine with history-based cooldown and optional timezone-aware clustering (±2hr UTC offset buckets)
- Configurable group size (2–8), per-channel cron scheduling with IANA timezones
- App Home tab showing each user's channel memberships
- Custom Hono receiver bridging Bolt events so there's a single HTTP layer
- Block Kit config modal for admins

## Why

Slack Donut is heavy and opinionated. This is a lighter reimplementation with improvements:
- Configurable group size (Donut hard-codes 3)
- Timezone-aware pairing as a toggle
- Fewer moving parts: 4 runtime deps, ~1,466 LOC
- Zero-infra storage (SQLite file)

Calendar integration is deferred to a later phase per initial scope.

## Not in this PR (Phase 4 follow-ups)

- Workspace credential persistence in the OAuth callback (currently logs only)
- Slack request signature verification middleware
- Rate limit handling
- README with Slack app manifest and setup guide

## Test plan

- [ ] `bun install && bunx tsc --noEmit` — passes locally
- [ ] `bunx drizzle-kit generate` — migration generated cleanly
- [ ] Install into a test Slack workspace and walk through `/donut setup` → `/donut join` → `/donut trigger`
- [ ] Verify DMs land for each paired group and channel announcement posts
- [ ] Configure a near-future cron and confirm the scheduler fires automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)